### PR TITLE
Handle malformed token expiration timestamps

### DIFF
--- a/amc_manager/services/token_service.py
+++ b/amc_manager/services/token_service.py
@@ -202,10 +202,15 @@ class TokenService:
                 return None
             
             # Check if token is expired
-            expires_at = datetime.fromisoformat(auth_tokens.get('expires_at', ''))
-            if expires_at > datetime.utcnow() + timedelta(minutes=5):
-                # Token is still valid (with 5-minute buffer)
-                return access_token
+            try:
+                expires_at = datetime.fromisoformat(auth_tokens.get('expires_at', ''))
+                if expires_at > datetime.utcnow() + timedelta(minutes=5):
+                    # Token is still valid (with 5-minute buffer)
+                    return access_token
+            except ValueError:
+                # If the timestamp is malformed, assume the token is expired and proceed
+                # to refresh logic instead of failing outright.
+                logger.warning("Invalid token expiration timestamp; refreshing token.")
             
             # Token is expired or about to expire, refresh it
             logger.info("Access token expired, attempting refresh...")


### PR DESCRIPTION
## Summary
- make token expiration handling robust by assuming refresh if timestamp parse fails

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68977884c338832f8218623bff0cf54e