### PR TITLE
fix: avoid shared mutable defaults

### DIFF
--- a/amc_manager/api/campaigns.py
+++ b/amc_manager/api/campaigns.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 from typing import List, Dict, Any, Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from datetime import datetime
 
 from ..core import AMCAPIClient, get_logger
@@ -19,7 +19,7 @@ router = APIRouter()
 class CampaignBrandTag(BaseModel):
     campaign_id: str
     brand_tag: str
-    metadata: Optional[Dict[str, Any]] = {}
+    metadata: Optional[Dict[str, Any]] = Field(default_factory=dict)
 
 
 class BrandConfigCreate(BaseModel):
@@ -27,9 +27,9 @@ class BrandConfigCreate(BaseModel):
     brand_name: str
     description: Optional[str] = None
     yaml_parameters: Optional[str] = None
-    default_parameters: Optional[Dict[str, Any]] = {}
-    primary_asins: Optional[List[str]] = []
-    campaign_name_patterns: Optional[List[str]] = []
+    default_parameters: Optional[Dict[str, Any]] = Field(default_factory=dict)
+    primary_asins: Optional[List[str]] = Field(default_factory=list)
+    campaign_name_patterns: Optional[List[str]] = Field(default_factory=list)
 
 
 @router.get("/dsp")

--- a/amc_manager/api/queries.py
+++ b/amc_manager/api/queries.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 from typing import List, Dict, Any, Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 import yaml
 
 from ..core import get_logger
@@ -19,7 +19,7 @@ router = APIRouter()
 class QueryBuildRequest(BaseModel):
     template_name: Optional[str] = None
     base_query: Optional[str] = None
-    parameters: Optional[Dict[str, Any]] = {}
+    parameters: Optional[Dict[str, Any]] = Field(default_factory=dict)
     yaml_config: Optional[str] = None
 
 
@@ -31,11 +31,11 @@ class QueryTemplateSave(BaseModel):
     name: str
     query: str
     description: str
-    parameters: Optional[Dict[str, Any]] = {}
-    tags: Optional[List[str]] = []
+    parameters: Optional[Dict[str, Any]] = Field(default_factory=dict)
+    tags: Optional[List[str]] = Field(default_factory=list)
     category: Optional[str] = None
     is_public: bool = False
-    example_parameters: Optional[Dict[str, Any]] = {}
+    example_parameters: Optional[Dict[str, Any]] = Field(default_factory=dict)
 
 
 @router.get("/templates")

--- a/amc_manager/api/workflows.py
+++ b/amc_manager/api/workflows.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 from typing import List, Dict, Any, Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from ..core import AMCAPIClient, get_logger
 from ..models import get_db, User, Workflow
@@ -20,8 +20,8 @@ class WorkflowCreate(BaseModel):
     description: Optional[str] = None
     instance_id: str
     sql_query: str
-    parameters: Optional[Dict[str, Any]] = {}
-    tags: Optional[List[str]] = []
+    parameters: Optional[Dict[str, Any]] = Field(default_factory=dict)
+    tags: Optional[List[str]] = Field(default_factory=list)
 
 
 class WorkflowUpdate(BaseModel):
@@ -34,13 +34,13 @@ class WorkflowUpdate(BaseModel):
 
 
 class WorkflowExecute(BaseModel):
-    parameters: Optional[Dict[str, Any]] = {}
+    parameters: Optional[Dict[str, Any]] = Field(default_factory=dict)
 
 
 class ScheduleCreate(BaseModel):
     cron_expression: str
     timezone: str = "UTC"
-    default_parameters: Optional[Dict[str, Any]] = {}
+    default_parameters: Optional[Dict[str, Any]] = Field(default_factory=dict)
 
 
 @router.post("/")


### PR DESCRIPTION
## Summary
- avoid shared mutable defaults in FastAPI request models to prevent cross-request state leaks

## Testing
- `pytest` *(fails: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_689776798d54832f99708e9671cd0542